### PR TITLE
fix loop to handle multiple sessions

### DIFF
--- a/source/lambda/save_auto_session/index.js
+++ b/source/lambda/save_auto_session/index.js
@@ -41,8 +41,9 @@ exports.handler = async (event, context) => {
                 "Item": myItem
             }).promise()
             console.log(`Item inserted, sessionid=${item['Data'][0]['VarCharValue']}`);            
-            return "OK";
+            
         }
+        return "OK";
     }else{
         
         throw new Error('Event received must be an array with at least 2 elements');


### PR DESCRIPTION
*Issue #, if available:*
Multiple sessions were not saved to DynamoDB table
*Description of changes:*

When multiple sessions are detected by Athena query, the loop that goes though all the sessions was stopping after the first item. So only one item was inserted in DynamoDb table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
