### PR TITLE
Update v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2023-04-14
+### Changed
+- Updated object ownership configuration on on the ApiEndpointsLogsBucket bucket
+
 ## [1.1.1] - 2023-2-2
 ### Added
 - Added architecture diagram.

--- a/source/lib/api/endpoints.ts
+++ b/source/lib/api/endpoints.ts
@@ -54,6 +54,7 @@ export class Endpoints extends Construct {
 
     const s3Logs = new s3.Bucket(this, "LogsBucket", {
       encryption: s3.BucketEncryption.S3_MANAGED,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
       blockPublicAccess: new s3.BlockPublicAccess({
         blockPublicPolicy: true,
         blockPublicAcls: true,


### PR DESCRIPTION
Background
=========
An upcoming update on AWS S3 causes issues where S3 Buckets cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced settings.
To remediate this issue, the bucket policy is being updated to grant PutObject access to the logging service principal

Changes
=======
* Updated object ownership configuration on ApiEndpointsLogsBucket S3 Bucket
* Updated buildspec nodejs version from 14 to 16

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
