### PR TITLE
Updates CDK to latest version 2.125.0

### DIFF
--- a/source/cdk.json
+++ b/source/cdk.json
@@ -3,6 +3,6 @@
   "context": {
     "solution_id": "SO0195",
     "solution_name": "Secure Media Delivery at the Edge on AWS",
-    "solution_version": "v1.2.1"
+    "solution_version": "v1.2.2"
   }
 }

--- a/source/lib/api/endpoints.ts
+++ b/source/lib/api/endpoints.ts
@@ -28,9 +28,9 @@ import {
 
 import { Construct } from "constructs";
 
-import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
-import { HttpIamAuthorizer } from "@aws-cdk/aws-apigatewayv2-authorizers-alpha";
-import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-alpha";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import { HttpIamAuthorizer } from "aws-cdk-lib/aws-apigatewayv2-authorizers";
+import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
 import { CfnStage } from "aws-cdk-lib/aws-apigatewayv2";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { IFunction } from "aws-cdk-lib/aws-lambda";

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -1,20 +1,17 @@
 {
   "name": "cdk-solution",
-  "version": "v1.2.1",
+  "version": "v1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk-solution",
-      "version": "v1.2.1",
+      "version": "v1.2.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "^2.95.1-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.95.1-alpha.0",
-        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.95.1-alpha.0",
-        "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.95.1-alpha.0",
-        "aws-cdk-lib": "^2.95.1",
+        "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.125.0-alpha.0",
+        "aws-cdk-lib": "^2.125.0",
         "constructs": "^10.0.0",
         "joi": "^17.6.0",
         "prompts": "^2.4.2",
@@ -39,7 +36,7 @@
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
         "adm-zip": "^0.5.10",
-        "aws-cdk": "2.95.1",
+        "aws-cdk": "^2.125.0",
         "aws-sdk-client-mock": "^2.2.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
@@ -71,9 +68,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.200",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
+      "version": "2.2.202",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
+      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
@@ -85,53 +82,15 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
-    "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.95.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.95.1-alpha.0.tgz",
-      "integrity": "sha512-01CjocOWbt5XF2aaLWXSOrWlCevmebwLUtivlRhCMpLXfpIQVwMRWbPdzZvpjcsUm5e3ptHUe9aNDZfpWEWahg==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "2.95.1",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
-      "version": "2.95.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.95.1-alpha.0.tgz",
-      "integrity": "sha512-FrSYoo+/jBHSPSxjEobm7TS6a7lJd0rtMIlCc6jBKwf+sy74T6qW9t6wqZgMBXc9L3Oo+lJiuXYUjR4HLPECqw==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.95.1-alpha.0",
-        "aws-cdk-lib": "2.95.1",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
-      "version": "2.95.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.95.1-alpha.0.tgz",
-      "integrity": "sha512-ULNS6N08YFDZ7bgyPEcSYfqdenfieBD0/LYME0a0DCmRWrTQgAtZm3jR+xOlYUvd0UxeoR9/3NjjohjAmO/vIA==",
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.95.1-alpha.0",
-        "aws-cdk-lib": "2.95.1",
-        "constructs": "^10.0.0"
-      }
-    },
     "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
-      "version": "2.95.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.95.1-alpha.0.tgz",
-      "integrity": "sha512-i2UpAJT8WSKhJgUF46xilwVR8HsxQX1kcZxOMWikbPRN/PDch7NCUyLGVtTe7y4K9za6icyJOFpyw2E9tptH7w==",
+      "version": "2.125.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.125.0-alpha.0.tgz",
+      "integrity": "sha512-kWTRCWcsFnURD8ldMprwby9TVCpsEhfGdQwY37u32hSyM3fc59EswLCM4rPJvXYpGJdy5BcuIll2mJItktL/6g==",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.95.1",
+        "aws-cdk-lib": "^2.125.0",
         "constructs": "^10.0.0"
       }
     },
@@ -4361,9 +4320,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.95.1.tgz",
-      "integrity": "sha512-KUJ63n2cB6qxpsHARmMWDhu8VITA7rKvYybbfS7BaBpXl4Tb9Bt/mEAY1EeVeyO/mpInvSRpMpdjyqE0kNAKtA==",
+      "version": "2.125.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.125.0.tgz",
+      "integrity": "sha512-6qFtaDPzhddhwIbCpqBjMePzZS7bfthGFQYfcwF1OhqMv2f3VpHQQ0f7kz4UxXJXUIR5BbgCnlpawH3c0aNzKw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -4376,9 +4335,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.95.1.tgz",
-      "integrity": "sha512-FQlnW3+c1j2W7hmu+QMSiWnBgbW1Lhn1ZpBQ6cwYZa97rII1zlEyTowAfzQk6szPIzUhJv5xK03nWZtvCvpAWw==",
+      "version": "2.125.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.125.0.tgz",
+      "integrity": "sha512-yRcHuvpPYHuvffeJCnTSIqo6y+Qjeuf+BKmr/oyMcMhyfIzcGFFhh+ZQRCTYIJTfTyU6nh73TLhsZ4TmzFuBBA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4392,16 +4351,16 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.0",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
+        "punycode": "^2.3.1",
         "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
@@ -4517,7 +4476,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4535,7 +4494,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4602,7 +4561,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4687,7 +4646,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk-solution",
-  "version": "v1.2.1",
+  "version": "v1.2.2",
   "description": "Synthesize templates for Secure Media Delivery at the Edge on AWS using AWS Cloud Development Kit (CDK).",
   "license": "Apache-2.0",
   "author": {
@@ -37,20 +37,17 @@
     "@types/prompts": "^2.0.14",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
-    "aws-cdk": "2.95.1",
+    "adm-zip": "^0.5.10",
+    "aws-cdk": "^2.125.0",
     "aws-sdk-client-mock": "^2.2.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.7.0",
-    "typescript": "^5.0.4",
-    "adm-zip": "^0.5.10"
+    "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.95.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.95.1-alpha.0",
-    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.95.1-alpha.0",
-    "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.95.1-alpha.0",
-    "aws-cdk-lib": "^2.95.1",
+    "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.125.0-alpha.0",
+    "aws-cdk-lib": "^2.125.0",
     "constructs": "^10.0.0",
     "joi": "^17.6.0",
     "prompts": "^2.4.2",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I've updated aws-cdk and aws-cdk-lib to 2.125.0, and removed the now deprecated use of the alpha apigateway modules.  I've also bumped a the previously missed solution version numbers to v1.2.2 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
