### PR TITLE
fix: install source/lambda deps in postinstall + deploy

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -11,10 +11,11 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "postinstall": "npm run build",
+    "postinstall": "npm run build && npm run lambda:install",
+    "lambda:install": "npm install --prefix lambda --omit=dev --no-audit --no-fund",
     "build": "npx tsc",
     "test": "jest --coverage",
-    "deploy": "npx cdk deploy --all",
+    "deploy": "npm run lambda:install && npx cdk deploy --all",
     "wizard": "node dist/bin/wizard/index.js",
     "bootstrap": "npx cdk bootstrap"
   },


### PR DESCRIPTION
## Summary

`source/lambda/package.json` declares `cbor-x` and `@aws-sdk/*` as runtime dependencies, but no build step actually installs them. A fresh `cdk deploy` from a clean clone uploads the token generator zip without its `node_modules`, and `CTAGenerator` crashes with `Cannot find module 'cbor-x'` on first invocation.

## Change

Adds a `lambda:install` npm script that installs `source/lambda/`'s deps (production only, quiet), and wires it into two places:

- **postinstall** — `npm install` at `source/` now hydrates everything
- **deploy** — belt-and-braces for fresh CI checkouts where postinstall ran before the tree was populated

Diff is 3 lines in `source/package.json`.

## Test plan
- [x] Fresh clone → `cd source && npm install` → `source/lambda/node_modules/` populated
- [x] `npm run deploy` → CTAGenerator invocation returns a token (previously crashed)
- [x] Existing `npm test` still passes