### PR TITLE
fix: strip /api prefix at edge so CloudFront -> APIGW routes match

### DIFF
--- a/source/lib/cta-secure-media-stack.ts
+++ b/source/lib/cta-secure-media-stack.ts
@@ -209,6 +209,25 @@ export class CTASecureMediaStack extends Stack {
     const revokeResource = api.root.addResource("revoke");
     revokeResource.addMethod("POST", new apigateway.LambdaIntegration(revoker));
 
+    // Rewrite /api/foo -> /foo before the /api/* behavior forwards to APIGW.
+    // RestApiOrigin sets originPath = /prod, so without this the request
+    // arrives at APIGW as /prod/api/token and 403s against APIGW's
+    // /prod/token route. Stripping /api at the edge keeps the public URL
+    // shape (/api/token) and lets APIGW's routes stay clean.
+    const apiPathRewriter = new cloudfront.Function(this, "CTAApiPathRewriter", {
+      functionName: `${Aws.STACK_NAME}-api-path-rewriter`,
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline(
+        "function handler(event) {\n" +
+        "  var req = event.request;\n" +
+        "  if (req.uri.indexOf('/api/') === 0) {\n" +
+        "    req.uri = req.uri.substring(4);\n" +
+        "  }\n" +
+        "  return req;\n" +
+        "}\n"
+      ),
+    });
+
     // Demo website (conditional)
     let distribution: cloudfront.Distribution;
     let demoBucket: s3.Bucket | undefined;
@@ -248,6 +267,10 @@ export class CTASecureMediaStack extends Stack {
             allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
             cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
             originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+            functionAssociations: [{
+              function: apiPathRewriter,
+              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+            }],
           },
           "/website/*": {
             origin: S3BucketOrigin.withOriginAccessControl(demoBucket),


### PR DESCRIPTION
## Summary

The `/api/*` CloudFront behavior forwards to a `RestApiOrigin` with `originPath: /prod`. The full request path is passed through unchanged, so a viewer request for `/api/token` arrives at API Gateway as `/prod/api/token` — which doesn't match APIGW's `/prod/token` route. Every legitimate call through CloudFront gets:

```
403 {"message": "Missing Authentication Token"}
```

Callers have to bypass CloudFront (hitting API Gateway directly) to get a working token endpoint — which also skips anything else attached to the distribution (realtime logs, geo restriction, any future WAF, etc).

## Change

Adds a small CloudFront Function on the `/api/*` behavior's `VIEWER_REQUEST` event that strips the `/api` prefix at the edge:

- `/api/token`   → `/token`
- `/api/revoke`  → `/revoke`
- `/api/revoked` → `/revoked`

The public URL shape stays `/api/*`; API Gateway's routes stay clean.

## Test plan
- [x] `POST /api/token` via CloudFront → 200 with valid token (previously 403)
- [x] `POST /api/revoke` via CloudFront → 200
- [x] `GET  /api/revoked` via CloudFront → 200
- [x] Direct APIGW calls (bypass CF) unchanged