### PR TITLE
feat: rate-limit POST /api/token via WAFv2

### DIFF
--- a/source/lib/cta-secure-media-stack.ts
+++ b/source/lib/cta-secure-media-stack.ts
@@ -19,6 +19,7 @@ import {
   aws_events as events,
   aws_events_targets as targets,
   aws_kinesis as kinesis,
+  aws_wafv2 as wafv2,
   custom_resources,
 } from "aws-cdk-lib";
 
@@ -209,10 +210,66 @@ export class CTASecureMediaStack extends Stack {
     const revokeResource = api.root.addResource("revoke");
     revokeResource.addMethod("POST", new apigateway.LambdaIntegration(revoker));
 
+    // WAFv2 Web ACL — rate-limit POST /api/token per source IP.
+    //: automated-scraping mitigation. Rate-based rules use a
+    // rolling 5-minute window; 300 req/5min ≈ 60 req/min per IP, well
+    // above legitimate player traffic (mint once → 2h TTL → next mint)
+    // but tight enough to stop a mint-your-own-token scraper.
+    // Blocked requests get a custom 429 response instead of the default 403.
+    const rateLimitBody = "CTAWebAclRateLimit429";
+    const webAcl = new wafv2.CfnWebACL(this, "CTAWebAcl", {
+      name: `${Aws.STACK_NAME}-token-rate-limit`,
+      description: "Rate-limit POST /api/token to mitigate automated CWT minting",
+      scope: "CLOUDFRONT",
+      defaultAction: { allow: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: `${Aws.STACK_NAME}-web-acl`,
+        sampledRequestsEnabled: true,
+      },
+      customResponseBodies: {
+        [rateLimitBody]: {
+          contentType: "APPLICATION_JSON",
+          content: JSON.stringify({ error: "rate_limited", message: "Too many token mint requests from this IP; try again in a few minutes." }),
+        },
+      },
+      rules: [{
+        name: "TokenMintRateLimit",
+        priority: 0,
+        action: {
+          block: {
+            customResponse: {
+              responseCode: 429,
+              customResponseBodyKey: rateLimitBody,
+            },
+          },
+        },
+        statement: {
+          rateBasedStatement: {
+            limit: 300,
+            aggregateKeyType: "IP",
+            scopeDownStatement: {
+              byteMatchStatement: {
+                fieldToMatch: { uriPath: {} },
+                positionalConstraint: "STARTS_WITH",
+                searchString: "/api/token",
+                textTransformations: [{ priority: 0, type: "NONE" }],
+              },
+            },
+          },
+        },
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName: `${Aws.STACK_NAME}-token-rate-limit`,
+          sampledRequestsEnabled: true,
+        },
+      }],
+    });
+
     // Demo website (conditional)
     let distribution: cloudfront.Distribution;
     let demoBucket: s3.Bucket | undefined;
-    
+
     if (config.main.enableDemo) {
       demoBucket = new s3.Bucket(this, "DemoWebsite", {
         removalPolicy: RemovalPolicy.DESTROY,
@@ -227,6 +284,7 @@ export class CTASecureMediaStack extends Stack {
       });
 
       distribution = new cloudfront.Distribution(this, "CTADistribution", {
+        webAclId: webAcl.attrArn,
         defaultBehavior: {
           origin: new HttpOrigin("cdn.mediaplaypen.com"),
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -257,6 +315,7 @@ export class CTASecureMediaStack extends Stack {
 
     } else {
       distribution = new cloudfront.Distribution(this, "CTADistribution", {
+        webAclId: webAcl.attrArn,
         defaultBehavior: {
           origin: new RestApiOrigin(api),
           functionAssociations: [{
@@ -388,6 +447,11 @@ export class CTASecureMediaStack extends Stack {
     new CfnOutput(this, "RotationWorkflow", {
       value: rotationWorkflow.stateMachineName,
       description: "Key rotation Step Functions workflow"
+    });
+
+    new CfnOutput(this, "WebAclArn", {
+      value: webAcl.attrArn,
+      description: "WAFv2 Web ACL — rate-limits POST /api/token"
     });
   }
 


### PR DESCRIPTION
## Summary

The `/api/token` endpoint is publicly reachable and mints a fresh CWT on every POST. In production that's a real abuse vector — anyone who finds the URL can mint valid tokens as fast as they can POST, and each minted token is valid until its `exp` claim (typically hours).

Adds a WAFv2 Web ACL (CLOUDFRONT scope) attached to the distribution, with a rate-based rule scoped to `STARTS_WITH /api/token`.

## Design

- **Threshold**: 300 requests per rolling 5-minute window per source IP (~60/min). Well above legitimate traffic given typical 2h CWT TTLs — one mint per session in the common case — but tight enough to stop a mint-your-own-token scraper.
- **Response**: 429 with a JSON body (`{"error":"rate_limited",...}`) instead of WAF's default 403. Clients can distinguish rate-limit from auth failures.
- **Default action**: `allow` — this ACL only rate-limits `/api/token`; everything else on the distribution passes through untouched.
- **CloudWatch metrics** enabled on both the ACL and the rule for tuning visibility.

The limit is a reasonable default for the reference solution — happy to make it a construct prop if that's preferred.

## Test plan
- [x] Hammer with 400 requests → limit trips around ~300
- [x] Subsequent requests → 429 with custom JSON body
- [x] Non-`/api/token` traffic → unaffected
- [x] CloudWatch metrics appear under `<StackName>-web-acl` / `<StackName>-token-rate-limit`