### PR TITLE
fix: add explicit dep from validator function to KVS to avoid intermittent deploy race

### DIFF
--- a/source/lib/cta-secure-media-stack.ts
+++ b/source/lib/cta-secure-media-stack.ts
@@ -76,13 +76,24 @@ export class CTASecureMediaStack extends Stack {
       comment: "CTA token revocation list",
     });
 
-    // CTA validator function
+    // CTA validator function.
+    //
+    // Explicit addDependency on the KVS: CloudFront KeyValueStore is a
+    // two-phase AWS resource (Provisioning -> Ready). The L2 construct
+    // returns the ARN before the store is Ready, so without this
+    // dependency CDK can order the CF Function's KeyValueStoreAssociations
+    // before the KVS is Ready and CloudFormation fails with:
+    //   "cannot be associated before the resource is provisioned"
+    // The failure is intermittent — it depends on CDK's graph traversal
+    // order — which makes it especially frustrating to debug on a fresh
+    // deploy.
     const validator = new cloudfront.Function(this, "CTAValidator", {
       code: cloudfront.FunctionCode.fromFile({ filePath: "lambda/cta_token_validator.js" }),
       functionName: `${Aws.STACK_NAME}-CTA-Validator`,
       runtime: cloudfront.FunctionRuntime.JS_2_0,
       keyValueStore: this.kvStore,
     });
+    validator.node.addDependency(this.kvStore);
 
     // Token generator (Node SDK)
     const generator = new lambda.Function(this, "CTAGenerator", {


### PR DESCRIPTION
## Summary

CloudFront KeyValueStore is a **two-phase resource**: the ARN is returned immediately at create time, but the store itself stays in `Provisioning` until `Ready`. The L2 `cloudfront.Function` construct's `keyValueStore` prop threads only the ARN — CDK's graph traversal can (and sometimes does) order the CFN `KeyValueStoreAssociations` before the store itself reaches `Ready`.

When that happens, CloudFormation fails first-deploy with:

```
Resource handler returned message:
  "The KVS cannot be associated before the resource is provisioned"
```

Failure is intermittent — depends on which order CDK happens to emit resources — which makes it especially annoying to debug on a fresh account. Once one deploy succeeds it typically stays sticky.

## Change

Adds a single line:

```ts
validator.node.addDependency(this.kvStore);
```

Forces CDK to always order the Function after the KVS, side-stepping the race.

## Test plan
- [x] Fresh account: `cdk deploy` succeeds first try (previously intermittent)
- [x] Re-deploy on existing stack: no-op
- [x] Verified template diff shows the added `DependsOn` clause on the Function