### PR TITLE
docs: add Community ports section (link to a Terraform port)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,9 @@ A scheduled Lambda runs hourly to purge expired revocation entries from KeyValue
 - Node.js 22+
 - AWS CDK v2.79.1+
 - AWS account with CloudFront Functions CWT support
+
+## Community ports
+
+If you'd rather deploy this stack with Terraform than CDK, a community-maintained port is available:
+
+- **Terraform**: [playon/terraform-aws-cta-secure-media](https://github.com/playon/terraform-aws-cta-secure-media) — feature-parity port as a reusable Terraform module. Vendors the Lambda runtime code from this repo unchanged; exposes the validator function ARN, KVS ARN, and API endpoint as module outputs so consumers can attach the validator to their own distribution.


### PR DESCRIPTION
## Summary

Adds a short **Community ports** section to the README pointing readers who prefer Terraform to a feature-parity port of this stack: [playon/terraform-aws-cta-secure-media](https://github.com/playon/terraform-aws-cta-secure-media).

The port:
- Vendors the Lambda runtime code from this repo unchanged (Apache-2.0, credited in `NOTICE`)
- Ships as a reusable Terraform module (`module "cta" { source = "github.com/playon/terraform-aws-cta-secure-media" }`)
- Exposes `validator_function_arn`, `kvs_arn`, and `api_endpoint` as outputs so consumers can attach the validator to their own CloudFront distribution
- Includes the same WAF rate limit, `/api/*` path rewriter, and KVS association fix from the other three PRs in this series (all self-contained in the module)

Happy to reshape the framing if you'd prefer a different presentation (e.g., a dedicated `docs/community-ports.md` file, or omit entirely).

## Test plan
- [x] README renders correctly on GitHub (no broken markdown)
- [x] Link resolves to a real, public repo under a permissive license